### PR TITLE
empty resumption token create an error in the client

### DIFF
--- a/sickle/iterator.py
+++ b/sickle/iterator.py
@@ -144,7 +144,7 @@ class OAIItemIterator(BaseOAIIterator):
                 if self.ignore_deleted and mapped.deleted:
                     continue
                 return mapped
-            if self.resumption_token:
+            if self.resumption_token and self.resumption_token.token:
                 self._next_response()
             else:
                 raise StopIteration


### PR DESCRIPTION
According to the XSD grammar it is possible to have an empty resumptionToken. This creates an exception in the client:

```
Traceback (most recent call last):
  File "oai-sickle.py", line 15, in <module>
    for rec in records:
  File "xxxxxxx\python-2.7.6\lib\site-packages\sickle\iterator.py", line 148, in next
    self._next_response()
  File "xxxxxxx\python-2.7.6\lib\site-packages\sickle\iterator.py", line 135, in _next_response
    super(OAIItemIterator, self)._next_response()
  File "xxxxxxx\python-2.7.6\lib\site-packages\sickle\iterator.py", line 89, in _next_response
    oaiexceptions, code[0].upper() + code[1:])(description)
BadArgument: Bad argument: metadataPrefix

Bad argument: metadataPrefix
```

```
<OAI-PMH xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.openarchives.org/OAI/2.0/" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd">
<SCRIPT/>
<responseDate>2015-06-30T12:55:54Z</responseDate>
<request verb="ListIdentifiers" metadataPrefix="iso19139" from="2015-06-01T23:59:59Z" until="2015-06-28T23:59:59Z">xxxxxxxxxxxx</request>
<ListIdentifiers>
<header>
<identifier>xxxxxxxx</identifier>
<datestamp>2014-10-24T00:00:00Z</datestamp>
<setSpec>blah</setSpec>
</header>
<resumptionToken cursor="0" completeListSize="46"/>
</ListIdentifiers>

I have implemented a quick fix by just testing the existence of the token attribute in the resumption token itself. You might want to do it differently. 

```
